### PR TITLE
Change AttributeMapper to use metaclasses

### DIFF
--- a/anemoi/Tests/test_Meta.py
+++ b/anemoi/Tests/test_Meta.py
@@ -26,10 +26,6 @@ class TestMeta(unittest.TestCase):
                 'i':            (True,      '_mustexist',  np.int64),
             }
             
-            def __init__(self, systemConfig):
-                
-                super(TestAttributeMapper, self).__init__(systemConfig)
-
         class TestType(object):
             
             pass
@@ -47,7 +43,7 @@ class TestMeta(unittest.TestCase):
         try:
             tam = TestAttributeMapper(systemConfig)
         except Exception as e:
-            if e.args[0] == 'AttributeMapper subclass TestAttributeMapper requires parameter \'i\'!':
+            if e.args[0] == 'Class TestAttributeMapper requires parameter \'i\'!':
                 exceptionFired = True
             else:
                 exceptionFired = False

--- a/anemoi/__init__.py
+++ b/anemoi/__init__.py
@@ -1,4 +1,4 @@
-from analytical import AnalyticalHelmholtz
-from minizephyr import MiniZephyr, MiniZephyr25D
-from eurus import Eurus
-from sources import SimpleSource, StackedSimpleSource
+from .analytical import AnalyticalHelmholtz
+from .minizephyr import MiniZephyr, MiniZephyr25D
+from .eurus import Eurus
+from .sources import SimpleSource, StackedSimpleSource

--- a/anemoi/eurus.py
+++ b/anemoi/eurus.py
@@ -9,15 +9,8 @@ class Eurus(BaseDiscretization):
     
     initMap = {
     #   Argument        Required    Rename as ...   Store as type
-        'c':            (True,      '_c',           np.complex128),
-        'rho':          (False,     '_rho',         np.float64),
         'nPML':         (False,     '_nPML',        np.int64),
         'freq':         (True,      None,           np.complex128),
-        'dx':           (True,      None,           np.float64),
-        'dz':           (True,      None,           np.float64),
-        'nx':           (True,      None,           np.int64),
-        'nz':           (True,      None,           np.int64),
-        'freeSurf':     (False,     None,           list),
         'mord':         (False,     '_mord',        tuple),
         'theta':        (False,     '_theta',       np.float64),
         'eps':          (False,     '_eps',         np.float64),
@@ -459,23 +452,6 @@ class Eurus(BaseDiscretization):
     def nPML(self):
         return getattr(self, '_nPML', 10)
     
-    @property
-    def c(self):
-        if isinstance(self._c, np.ndarray):
-            return self._c
-        else:
-            return self._c * np.ones((self.nz, self.nx), dtype=np.complex128)
-        
-    @property
-    def rho(self):
-        if getattr(self, '_rho', None) is None:
-            self._rho = 310. * self.c**0.25 
-            
-        if isinstance(self._rho, np.ndarray):
-            return self._rho
-        else:
-            return self._rho * np.ones((self.nz, self.nx), dtype=np.float64)
-
     @property
     def theta(self):
         if getattr(self, '_theta', None) is None:

--- a/anemoi/eurus.py
+++ b/anemoi/eurus.py
@@ -1,5 +1,5 @@
 
-from anemoi.meta import BaseDiscretization
+from .meta import BaseDiscretization
 
 import numpy as np
 import scipy.sparse

--- a/anemoi/meta.py
+++ b/anemoi/meta.py
@@ -2,39 +2,169 @@
 import warnings
 import numpy as np
 
-class AttributeMapper(object):
+class AMMetaClass(type):
     
-    initMap = {}
+    def __new__(mcs, name, bases, attrs):
+        
+        baseMaps = [getattr(base, 'initMap', {}) for base in bases][::-1]
+        baseMaps.append(attrs.get('initMap', {}))
+        
+        initMap = {}
+        for baseMap in baseMaps:
+            initMap.update(baseMap)
+        
+        attrs['initMap'] = initMap
+        
+        return type.__new__(mcs, name, bases, attrs)
     
-    def __init__(self, systemConfig):
+    def __call__(cls, *args, **kwargs):
+        
+        if len(args) < 1:
+            raise TypeError('__init__() takes at least 2 arguments (1 given) ZOMG!')
+        systemConfig = args[0]
+        
+        obj = cls.__new__(cls)
         
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            for key in self.initMap.keys():
-                if (key not in systemConfig) and self.initMap[key][0]:
-                    raise Exception('AttributeMapper subclass %s requires parameter \'%s\'!'%(self.__class__.__name__, key))
+            for key in obj.initMap.keys():
+                if (key not in systemConfig) and obj.initMap[key][0]:
+                    raise Exception('Class %s requires parameter \'%s\'!'%(cls.__name__, key))
                 if key in systemConfig:
-                    if self.initMap[key][2] is None:
+                    if obj.initMap[key][2] is None:
                         typer = lambda x: x
                     else:
                         def typer(x):
-                            newtype = self.initMap[key][2]
+                            newtype = obj.initMap[key][2]
                             try:
-                                return self.initMap[key][2](x)
+                                return obj.initMap[key][2](x)
                             except TypeError:
                                 if np.iscomplex(x) and issubclass(newtype, np.floating):
                                     return typer(x.real)
                                 raise
                                 
-                    if self.initMap[key][1] is None:
-                        setattr(self, key, typer(systemConfig[key]))
+                    if obj.initMap[key][1] is None:
+                        setattr(obj, key, typer(systemConfig[key]))
                     else:
-                        setattr(self, self.initMap[key][1], typer(systemConfig[key]))
+                        setattr(obj, obj.initMap[key][1], typer(systemConfig[key]))
+        
+        obj.__init__(*args, **kwargs)
+        return obj
 
+
+class AttributeMapper(object):
+    '''
+    An AttributeMapper subclass defines a dictionary initMap, which
+    includes keys for mappable inputs expected from the systemConfig
+    parameter. The dictionary takes the form:
+    
+    initMap = {
+    #   Argument        Required    Rename as ...   Store as type
+        'c':            (True,      '_c',           np.complex128),
+        'rho':          (False,     '_rho',         np.float64),
+        'freq':         (True,      None,           np.complex128),
+        'dx':           (False,     '_dx',          np.float64),
+        'dz':           (False,     '_dz',          np.float64),
+        'nx':           (True,      None,           np.int64),
+        'nz':           (True,      None,           np.int64),
+        'freeSurf':     (False,     '_freeSurf',    list),
+    }
+    
+    Each value in the dictionary is a tuple, which is interpreted by
+    the baseclass (i.e., AttributeMapper) to determine how to process
+    the value corresponding to the same key in systemConfig.
+    
+    An exception will be raised if the first element in the tuple
+    is set to true, but the corresponding key does not exist in the
+    systemConfig parameter.
+    
+    If the second element in the tuple is set to None, the key will be
+    assigned to the subclass's attribute dictionary unmodified, whereas
+    if the second element is a string then that will be the assigned key.
+    
+    If the third element in the tuple is set to None, the input argument
+    will be set unmodified; however, if the third element is a class
+    then it will be applied to the element (e.g., to allow typecasting).
+    
+    NB: Complex numpy arguments are handled specially, and the real part
+    of their value is returned when they are typecast to a float.
+    '''
+    
+    __metaclass__ = AMMetaClass
+    
+    def __init__(self, systemConfig):
+        pass
+
+    
 class BaseDiscretization(AttributeMapper):
     
-    pass
+    initMap = {
+    #   Argument        Required    Rename as ...   Store as type
+        'c':            (True,      '_c',           np.complex128),
+        'rho':          (False,     '_rho',         np.float64),
+        'freq':         (True,      None,           np.complex128),
+        'dx':           (False,     '_dx',          np.float64),
+        'dz':           (False,     '_dz',          np.float64),
+        'nx':           (True,      None,           np.int64),
+        'nz':           (True,      None,           np.int64),
+        'freeSurf':     (False,     '_freeSurf',    list),
+    }
+    
+    @property
+    def c(self):
+        if isinstance(self._c, np.ndarray):
+            return self._c
+        else:
+            return self._c * np.ones((self.nz, self.nx), dtype=np.complex128)
+    
+    @property
+    def rho(self):
+        if getattr(self, '_rho', None) is None:
+            self._rho = 310. * self.c**0.25 
+            
+        if isinstance(self._rho, np.ndarray):
+            return self._rho
+        else:
+            return self._rho * np.ones((self.nz, self.nx), dtype=np.float64)
+        
+    @property
+    def dx(self):
+        return getattr(self, '_dx', 1.)
+    
+    @property
+    def dz(self):
+        return getattr(self, '_dz', self.dx)
+    
+    @property
+    def freeSurf(self):
+        if getattr(self, '_freeSurf', None) is None:
+            self._freeSurf = (False, False, False, False)
+        return self._freeSurf
 
 class BaseSource(AttributeMapper):
     
-    pass
+    initMap = {
+    #   Argument        Required    Rename as ...   Store as type
+        'xorig':        (False,     '_xorig',       np.float64),
+        'zorig':        (False,     '_zorig',       np.float64),
+        'dx':           (False,     '_dx',          np.float64),
+        'dz':           (False,     '_dz',          np.float64),
+        'nx':           (True,      None,           np.int64),
+        'nz':           (True,      None,           np.int64),
+    }
+    
+    @property
+    def xorig(self):
+        return getattr(self, '_xorig', 0.)
+
+    @property
+    def zorig(self):
+        return getattr(self, '_zorig', 0.)
+    
+    @property
+    def dx(self):
+        return getattr(self, '_dx', 1.)
+    
+    @property
+    def dz(self):
+        return getattr(self, '_dz', 1.)

--- a/anemoi/meta.py
+++ b/anemoi/meta.py
@@ -71,23 +71,25 @@ class AttributeMapper(object):
     }
     
     Each value in the dictionary is a tuple, which is interpreted by
-    the baseclass (i.e., AttributeMapper) to determine how to process
-    the value corresponding to the same key in systemConfig.
+    the metaclass (i.e., AMMetaClass) to determine how to process the
+    value corresponding to the same key in systemConfig.
     
     An exception will be raised if the first element in the tuple
     is set to true, but the corresponding key does not exist in the
     systemConfig parameter.
     
     If the second element in the tuple is set to None, the key will be
-    assigned to the subclass's attribute dictionary unmodified, whereas
-    if the second element is a string then that will be the assigned key.
+    defined in the subclass's attribute dictionary as it stands, whereas
+    if the second element is a string then that overrides the key.
     
     If the third element in the tuple is set to None, the input argument
-    will be set unmodified; however, if the third element is a class
-    then it will be applied to the element (e.g., to allow typecasting).
+    will be set in the subclass dictionary unmodified; however, if the
+    third element is a callable then it will be applied to the element
+    (e.g., to allow copying and/or typecasting of inputs).
     
-    NB: Complex numpy arguments are handled specially, and the real part
-    of their value is returned when they are typecast to a float.
+    NB: Complex numpy arguments are handled specially: the real part of
+    the value is kept and the imaginary part is discarded when they are
+    typecast to a float.
     '''
     
     __metaclass__ = AMMetaClass

--- a/anemoi/meta.py
+++ b/anemoi/meta.py
@@ -20,7 +20,7 @@ class AMMetaClass(type):
     def __call__(cls, *args, **kwargs):
         
         if len(args) < 1:
-            raise TypeError('__init__() takes at least 2 arguments (1 given) ZOMG!')
+            raise TypeError('__init__() takes at least 2 arguments (1 given)')
         systemConfig = args[0]
         
         obj = cls.__new__(cls)

--- a/anemoi/minizephyr.py
+++ b/anemoi/minizephyr.py
@@ -17,16 +17,8 @@ class MiniZephyr(BaseDiscretization):
         
     initMap = {
     #   Argument        Required    Rename as ...   Store as type
-        'c':            (True,      '_c',           np.complex128),
-        'rho':          (False,     '_rho',         np.float64),
         'nPML':         (False,     '_nPML',        np.int64),
-        'freq':         (True,      None,           np.complex128),
         'ky':           (False,     '_ky',          np.float64),
-        'dx':           (False,     '_dx',          np.float64),
-        'dz':           (False,     '_dz',          np.float64),
-        'nx':           (True,      None,           np.int64),
-        'nz':           (True,      None,           np.int64),
-        'freeSurf':     (False,     '_freeSurf',    list),
         'mord':         (False,     '_mord',        tuple),
         'premul':       (False,     '_premul',      np.complex128),
     }
@@ -297,23 +289,6 @@ class MiniZephyr(BaseDiscretization):
         return getattr(self, '_mord', ('+nx', '+1'))
     
     @property
-    def c(self):
-        if isinstance(self._c, np.ndarray):
-            return self._c
-        else:
-            return self._c * np.ones((self.nz, self.nx), dtype=np.complex128)
-
-    @property
-    def rho(self):
-        if getattr(self, '_rho', None) is None:
-            self._rho = 310. * self.c**0.25 
-            
-        if isinstance(self._rho, np.ndarray):
-            return self._rho
-        else:
-            return self._rho * np.ones((self.nz, self.nx), dtype=np.float64)
-
-    @property
     def nPML(self):
         return getattr(self, '_nPML', 10)
 
@@ -321,20 +296,6 @@ class MiniZephyr(BaseDiscretization):
     def ky(self):
         return getattr(self, '_ky', 0.)
 
-    @property
-    def dx(self):
-        return getattr(self, '_dx', 1.)
-    
-    @property
-    def dz(self):
-        return getattr(self, '_dz', self.dx)
-    
-    @property
-    def freeSurf(self):
-        if getattr(self, '_freeSurf', None) is None:
-            self._freeSurf = (False, False, False, False)
-        return self._freeSurf
-    
     @property
     def premul(self):
         return getattr(self, '_premul', 1.)
@@ -356,7 +317,6 @@ class MiniZephyr25D(BaseDiscretization):
         'parallel':     (False,     '_parallel',    bool),
         'cmin':         (False,     '_cmin',        np.float64),
         'freq':         (True,      None,           np.complex128),
-        'c':            (True,      None,           np.float64),
     }
     
     def __init__(self, systemConfig):
@@ -449,3 +409,4 @@ class MiniZephyr25D(BaseDiscretization):
             u = (sp*rhs for sp in self.subProblems)
         
         return self.scaleTerm * reduce(np.add, u)
+

--- a/anemoi/minizephyr.py
+++ b/anemoi/minizephyr.py
@@ -1,5 +1,5 @@
 
-from anemoi.meta import BaseDiscretization
+from .meta import BaseDiscretization
 
 import copy
 import numpy as np

--- a/anemoi/sources.py
+++ b/anemoi/sources.py
@@ -1,20 +1,15 @@
 
 import numpy as np
 
-class SimpleSource(object):
+class SimpleSource(BaseSource):
     
     def __init__(self, systemConfig):
         
-        xorig   = systemConfig.get('xorig', 0.)
-        zorig   = systemConfig.get('zorig', 0.)
-        dx      = systemConfig.get('dx', 1.)
-        dz      = systemConfig.get('dz', 1.)
-        nx      = systemConfig['nx']
-        nz      = systemConfig['nz']
-
+        super(SimpleSource, self).__init__(systemConfig)
+        
         self._z, self._x = np.mgrid[
-            zorig : dz * nz : dz,
-            xorig : dx * nx : dx
+            self.zorig : self.dz * self.nz : self.dz,
+            self.xorig : self.dx * self.nx : self.dx
         ]
     
     def __call__(self, x, z):

--- a/anemoi/sources.py
+++ b/anemoi/sources.py
@@ -1,4 +1,5 @@
 
+from .meta import BaseSource
 import numpy as np
 
 class SimpleSource(BaseSource):


### PR DESCRIPTION
Overall, I think this is an improvement. It adds:
1. Subclasses of `AttributeMapper` only have to specify what's new about their requirements; if they inherit from something like `BaseDiscretization` and it has an `initMap` attribute, they will automatically inherit whichever keys they don't override.
2. The key initialization code runs _before_ `__init__` in the subclass, which means that it is not necessary to call `super(SubClass, self).__init__(systemConfig, *args, **kwargs)` just to add some code to `__init__`; though, fair to say, it may still be a good idea depending on the circumstances.

Suggest merging whenever we're comfortable with the changes.
