### PR TITLE
Break out model-dependent properties into a new baseclass.

### DIFF
--- a/anemoi/discretization.py
+++ b/anemoi/discretization.py
@@ -1,20 +1,15 @@
 
-from .meta import AttributeMapper
+from .meta import AttributeMapper, BaseModelDependent
 from .solver import DirectSolver
 import numpy as np
 
-class BaseDiscretization(AttributeMapper):
+class BaseDiscretization(BaseModelDependent):
     
     initMap = {
     #   Argument        Required    Rename as ...   Store as type
         'c':            (True,      '_c',           np.complex128),
         'rho':          (False,     '_rho',         np.float64),
         'freq':         (True,      None,           np.complex128),
-        'dx':           (False,     '_dx',          np.float64),
-        'dz':           (False,     '_dz',          np.float64),
-        'nx':           (True,      None,           np.int64),
-        'nz':           (True,      None,           np.int64),
-        'freeSurf':     (False,     '_freeSurf',    tuple),
         'Solver':       (False,     '_Solver',      None),
     }
     
@@ -28,26 +23,12 @@ class BaseDiscretization(AttributeMapper):
     @property
     def rho(self):
         if getattr(self, '_rho', None) is None:
-            self._rho = 310. * self.c**0.25 
+            self._rho = 310. * self.c**0.25
             
         if isinstance(self._rho, np.ndarray):
             return self._rho
         else:
             return self._rho * np.ones((self.nz, self.nx), dtype=np.float64)
-        
-    @property
-    def dx(self):
-        return getattr(self, '_dx', 1.)
-    
-    @property
-    def dz(self):
-        return getattr(self, '_dz', self.dx)
-    
-    @property
-    def freeSurf(self):
-        if getattr(self, '_freeSurf', None) is None:
-            self._freeSurf = (False, False, False, False)
-        return self._freeSurf
     
     @property
     def Ainv(self):


### PR DESCRIPTION
Model-dependent properties are now part of a new baseclass, which means that we have something to inherit from when we want features dealing with model size, etc., but not other aspects of something like `BaseDiscretization`.
